### PR TITLE
Syncing backup

### DIFF
--- a/src/pages/hnlive.tsx
+++ b/src/pages/hnlive.tsx
@@ -122,16 +122,18 @@ export default function HNLiveTerminal() {
       comments: ''
     };
     
+    // Always link username directly to HN
     const userLink = `<a href="https://news.ycombinator.com/user?id=${item.by}" 
       class="hn-username hover:underline"
       target="_blank"
       rel="noopener noreferrer"
+      onclick="event.stopPropagation()"
     >${item.by}</a>`;
     
     if (item.type === 'comment') {
       text = `${userLink} > ${item.text?.replace(/<[^>]*>/g, '')}`;
       links.main = `https://news.ycombinator.com/item?id=${item.id}`;
-      links.comments = ''; // Empty string for comments since it's a comment
+      links.comments = ''; 
     } else if (item.type === 'story') {
       text = `${userLink}: ${item.title || '[untitled]'}`;
       links.main = item.url || `https://news.ycombinator.com/item?id=${item.id}`;


### PR DESCRIPTION
This pull request includes a small change to the `HNLiveTerminal` component in the `src/pages/hnlive.tsx` file. The change ensures that the username link always directs to the Hacker News profile and stops the event propagation when the link is clicked.

* [`src/pages/hnlive.tsx`](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2R125-R136): Added an `onclick` attribute to the `userLink` anchor tag to stop event propagation when the username is clicked.