### PR TITLE
Improve queue handling with buffer and dynamic intervals

### DIFF
--- a/src/pages/hnlive.tsx
+++ b/src/pages/hnlive.tsx
@@ -37,6 +37,11 @@ interface SearchFilters {
   text: string;
 }
 
+const INITIAL_BUFFER_SIZE = 30;  // Number of items to fetch initially
+const UPDATE_INTERVAL = 30000;   // How often to fetch new items (30 seconds)
+const MIN_DISPLAY_INTERVAL = 800;  // Minimum time between displaying items
+const MAX_DISPLAY_INTERVAL = 2000; // Maximum time between displaying items
+
 const getStoredTheme = () => {
   try {
     const storedTheme = localStorage.getItem('hn-live-theme');
@@ -198,7 +203,22 @@ export default function HNLiveTerminal() {
       }
       setQueueSize(itemQueueRef.current.length);
 
-      setTimeout(processNext, 800 + Math.random() * 400);
+      // Calculate next update interval based on queue size
+      const queueSize = itemQueueRef.current.length;
+      let interval;
+      
+      if (queueSize > 20) {
+        // If queue is large, display faster
+        interval = MIN_DISPLAY_INTERVAL;
+      } else if (queueSize > 10) {
+        // Medium queue, moderate speed
+        interval = MIN_DISPLAY_INTERVAL + Math.random() * 500;
+      } else {
+        // Small queue, slower display to prevent empty periods
+        interval = MIN_DISPLAY_INTERVAL + Math.random() * (MAX_DISPLAY_INTERVAL - MIN_DISPLAY_INTERVAL);
+      }
+
+      setTimeout(processNext, interval);
     };
 
     processNext();
@@ -223,7 +243,6 @@ export default function HNLiveTerminal() {
   // Update polling logic
   useEffect(() => {
     const fetchMaxItem = async () => {
-      // Create new abort controller
       abortControllerRef.current = new AbortController();
       
       try {
@@ -232,13 +251,18 @@ export default function HNLiveTerminal() {
           intervalRef.current = undefined;
         }
 
+        // Initial fetch with larger buffer
         const response = await fetch('https://hacker-news.firebaseio.com/v0/maxitem.json', {
           signal: abortControllerRef.current.signal
         });
         const maxItem = await response.json();
         maxItemRef.current = maxItem;
         
-        const itemIds = Array.from({length: 15}, (_, i) => (maxItem - 14) + i);
+        // Fetch more items initially to build a buffer
+        const itemIds = Array.from(
+          {length: INITIAL_BUFFER_SIZE}, 
+          (_, i) => (maxItem - INITIAL_BUFFER_SIZE + 1) + i
+        );
         
         for (const id of itemIds) {
           if (!isRunning) return;
@@ -252,10 +276,11 @@ export default function HNLiveTerminal() {
               item.text !== '[deleted]' && 
               item.text !== '[dead]' &&
               !item.dead) {
-            await addItem(item);
+            addToQueue(item);
           }
         }
         
+        // Regular polling interval
         if (isRunning) {
           intervalRef.current = setInterval(async () => {
             try {
@@ -291,7 +316,7 @@ export default function HNLiveTerminal() {
               if (error instanceof Error && error.name === 'AbortError') return;
               console.error('Error in interval:', error);
             }
-          }, 30000);
+          }, UPDATE_INTERVAL);
         }
       } catch (error: unknown) {
         if (error instanceof Error && error.name === 'AbortError') return;
@@ -302,7 +327,6 @@ export default function HNLiveTerminal() {
     if (isRunning) {
       fetchMaxItem();
     } else {
-      // Abort any ongoing fetches when stopping
       abortControllerRef.current?.abort();
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
@@ -553,7 +577,7 @@ export default function HNLiveTerminal() {
                 <span className={`inline-block w-2 h-2 rounded-full ${isRunning ? 'bg-red-500' : 'bg-gray-500'}`}></span>
               </span>
               LIVE
-              {queueSize >= 10 && (
+              {queueSize >= 50 && (
                 <span className={`absolute -top-1 -right-6 min-w-[1.2rem] h-[1.2rem] 
                   ${options.theme === 'green' ? 'bg-green-500 text-black' : 'bg-[#ff6600] text-white'} 
                   rounded text-xs flex items-center justify-center font-bold`}
@@ -669,7 +693,7 @@ export default function HNLiveTerminal() {
                 <span className={`inline-block w-2 h-2 rounded-full ${isRunning ? 'bg-red-500' : 'bg-gray-500'}`}></span>
               </span>
               LIVE
-              {queueSize >= 10 && (
+              {queueSize >= 50 && (
                 <span className={`absolute -top-1 -right-6 min-w-[1.2rem] h-[1.2rem] 
                   ${options.theme === 'green' ? 'bg-green-500 text-black' : 'bg-[#ff6600] text-white'} 
                   rounded text-xs flex items-center justify-center font-bold`}


### PR DESCRIPTION
This pull request includes several updates to the `HNLiveTerminal` component in `src/pages/hnlive.tsx` to improve the performance and user experience of the live feed. The changes primarily focus on optimizing the item fetching and display intervals, as well as updating the queue size threshold for visual indicators.

### Performance and User Experience Improvements:

* Introduced constants for initial buffer size, update interval, and display intervals to control the fetching and displaying of items more efficiently.
* Adjusted the logic for calculating the next update interval based on the current queue size to ensure smoother item display.
* Modified the initial fetch to retrieve a larger buffer of items, improving the initial loading experience.
* Changed the regular polling interval to use the new `UPDATE_INTERVAL` constant for consistency.

### Visual Indicator Update:

* Updated the queue size threshold for displaying the live indicator badge from 10 to 50, reducing visual clutter when the queue is small. [[1]](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2L556-R580) [[2]](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2L672-R696)