### PR TITLE
Increase initial buffer size to 60 stories for better initial load

### DIFF
--- a/src/pages/hnlive.tsx
+++ b/src/pages/hnlive.tsx
@@ -37,7 +37,7 @@ interface SearchFilters {
   text: string;
 }
 
-const INITIAL_BUFFER_SIZE = 30;  // Number of items to fetch initially
+const INITIAL_BUFFER_SIZE = 60;  // Number of items to fetch initially
 const UPDATE_INTERVAL = 30000;   // How often to fetch new items (30 seconds)
 const MIN_DISPLAY_INTERVAL = 800;  // Minimum time between displaying items
 const MAX_DISPLAY_INTERVAL = 2000; // Maximum time between displaying items
@@ -579,7 +579,7 @@ export default function HNLiveTerminal() {
                 <span className={`inline-block w-2 h-2 rounded-full ${isRunning ? 'bg-red-500' : 'bg-gray-500'}`}></span>
               </span>
               LIVE
-              {queueSize >= 50 && (
+              {queueSize >= 100 && (
                 <span className={`absolute -top-1 -right-6 min-w-[1.2rem] h-[1.2rem] 
                   ${options.theme === 'green' ? 'bg-green-500 text-black' : 'bg-[#ff6600] text-white'} 
                   rounded text-xs flex items-center justify-center font-bold`}
@@ -695,7 +695,7 @@ export default function HNLiveTerminal() {
                 <span className={`inline-block w-2 h-2 rounded-full ${isRunning ? 'bg-red-500' : 'bg-gray-500'}`}></span>
               </span>
               LIVE
-              {queueSize >= 50 && (
+              {queueSize >= 100 && (
                 <span className={`absolute -top-1 -right-6 min-w-[1.2rem] h-[1.2rem] 
                   ${options.theme === 'green' ? 'bg-green-500 text-black' : 'bg-[#ff6600] text-white'} 
                   rounded text-xs flex items-center justify-center font-bold`}


### PR DESCRIPTION
This pull request includes changes to the `src/pages/hnlive.tsx` file to adjust the initial buffer size and update the conditions for displaying a queue size indicator. 

Key changes include:

* Increased the `INITIAL_BUFFER_SIZE` from 30 to 60 to fetch more items initially.
* Updated the condition for displaying the queue size indicator from `queueSize >= 50` to `queueSize >= 100` in two places within the `HNLiveTerminal` component. [[1]](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2L582-R582) [[2]](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2L698-R698)