### PR TITLE
style: make username color consistent across themes

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -14,11 +14,6 @@ body {
   height: 100vh;
 }
 
-[data-theme="og"] .hn-username,
-[data-theme="dog"] .hn-username {
-  color: #ff6600 !important;
-}
-
 .hn-username {
-  color: rgb(250 204 21);
+  color: #ff6600 !important;
 }


### PR DESCRIPTION
This pull request includes changes to the `src/index.css` file to simplify and standardize the styling of `.hn-username` elements.

Styling updates:

* Removed specific theme-based color settings for `.hn-username` under `[data-theme="og"]` and `[data-theme="dog"]`, consolidating the color to a single style.
* Updated the color of `.hn-username` to `#ff6600` with `!important` to ensure it overrides other styles.