### PR TITLE
Add localStorage persistence for autoscroll preference

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://hn.live/</loc>
-    <lastmod>2024-12-28</lastmod>
+    <lastmod>2024-12-29</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>

--- a/src/pages/hnlive.tsx
+++ b/src/pages/hnlive.tsx
@@ -69,7 +69,8 @@ const getStoredDirectLinks = () => {
 const getStoredAutoscroll = () => {
   try {
     const storedAutoscroll = localStorage.getItem('hn-live-autoscroll');
-    return storedAutoscroll === 'true';
+    // Return true if no value is stored (first visit) or if the stored value is 'true'
+    return storedAutoscroll === null ? true : storedAutoscroll === 'true';
   } catch (e) {
     console.warn('Could not access localStorage');
   }

--- a/src/pages/hnlive.tsx
+++ b/src/pages/hnlive.tsx
@@ -66,13 +66,23 @@ const getStoredDirectLinks = () => {
   return false; // Default to our site view
 };
 
+const getStoredAutoscroll = () => {
+  try {
+    const storedAutoscroll = localStorage.getItem('hn-live-autoscroll');
+    return storedAutoscroll === 'true';
+  } catch (e) {
+    console.warn('Could not access localStorage');
+  }
+  return true; // Default to autoscroll on
+};
+
 export default function HNLiveTerminal() {
   useDocumentTitle('Hacker News Live');
   
   const [items, setItems] = useState<HNItem[]>([]);
   const [options, setOptions] = useState<TerminalOptions>({
     theme: getStoredTheme(),
-    autoscroll: true,
+    autoscroll: getStoredAutoscroll(),
     directLinks: getStoredDirectLinks()
   });
   const [isRunning, setIsRunning] = useState(true);
@@ -566,6 +576,15 @@ export default function HNLiveTerminal() {
       console.warn('Could not save direct links preference');
     }
   }, [options.directLinks]);
+
+  // Add a new effect to save autoscroll changes
+  useEffect(() => {
+    try {
+      localStorage.setItem('hn-live-autoscroll', options.autoscroll.toString());
+    } catch (e) {
+      console.warn('Could not save autoscroll preference');
+    }
+  }, [options.autoscroll]);
 
   return (
     <>


### PR DESCRIPTION
This pull request includes updates to the `src/pages/hnlive.tsx` file to add functionality for persisting the autoscroll setting in localStorage, and a minor update to the `public/sitemap.xml` file.

Enhancements to autoscroll functionality:

* [`src/pages/hnlive.tsx`](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2R69-R85): Added a new function `getStoredAutoscroll` to retrieve the autoscroll setting from localStorage and updated the `HNLiveTerminal` component to use this function.
* [`src/pages/hnlive.tsx`](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2R580-R588): Added a new `useEffect` to save changes to the autoscroll setting in localStorage whenever it is updated.
