### PR TITLE
Add clickable logo for site reload functionality

### DIFF
--- a/src/pages/hnlive.tsx
+++ b/src/pages/hnlive.tsx
@@ -587,6 +587,19 @@ export default function HNLiveTerminal() {
     }
   }, [options.autoscroll]);
 
+  const reloadSite = () => {
+    // Clear existing items and queue
+    setItems([]);
+    processedIds.current.clear();
+    itemQueueRef.current = [];
+    setQueueSize(0);
+    maxItemRef.current = 0;
+    
+    // Reset running state to trigger reload
+    setIsRunning(false);
+    setTimeout(() => setIsRunning(true), 0);
+  };
+
   return (
     <>
       <Helmet>
@@ -626,7 +639,10 @@ export default function HNLiveTerminal() {
           {/* Mobile Layout */}
           <div className="sm:hidden">
             <div className="flex items-center justify-between mb-2">
-              <span className={`${headerColor} font-bold tracking-wider flex items-center gap-2 relative`}>
+              <span 
+                onClick={reloadSite}
+                className={`${headerColor} font-bold tracking-wider flex items-center gap-2 relative cursor-pointer hover:opacity-75 transition-opacity`}
+              >
                 HN
                 <span className="animate-pulse">
                   <span className={`inline-block w-2 h-2 rounded-full ${isRunning ? 'bg-red-500' : 'bg-gray-500'}`}></span>
@@ -742,7 +758,10 @@ export default function HNLiveTerminal() {
           {/* Desktop Layout */}
           <div className="hidden sm:flex items-center justify-between">
             <div className="flex items-center gap-4">
-              <span className={`${headerColor} font-bold tracking-wider flex items-center gap-2 relative`}>
+              <span 
+                onClick={reloadSite}
+                className={`${headerColor} font-bold tracking-wider flex items-center gap-2 relative cursor-pointer hover:opacity-75 transition-opacity`}
+              >
                 HN
                 <span className="animate-pulse">
                   <span className={`inline-block w-2 h-2 rounded-full ${isRunning ? 'bg-red-500' : 'bg-gray-500'}`}></span>


### PR DESCRIPTION
This pull request includes changes to the `HNLiveTerminal` component in the `src/pages/hnlive.tsx` file to add a reload functionality and improve user interaction. The most important changes include the addition of a `reloadSite` function and modifications to the mobile and desktop layouts to make the header clickable for reloading.

Enhancements to reload functionality and user interaction:

* Added a `reloadSite` function to clear existing items, reset the queue, and trigger a reload by toggling the `isRunning` state.
* Modified the mobile layout to make the header clickable, triggering the `reloadSite` function on click, and added styling for cursor pointer and hover opacity transition.
* Modified the desktop layout to make the header clickable, triggering the `reloadSite` function on click, and added styling for cursor pointer and hover opacity transition.