### PR TITLE
Add support for header text from environment variable

### DIFF
--- a/src/pages/hnlive.tsx
+++ b/src/pages/hnlive.tsx
@@ -600,6 +600,12 @@ export default function HNLiveTerminal() {
     setTimeout(() => setIsRunning(true), 0);
   };
 
+  // Add this near the top of the file with other state declarations
+  const [headerText] = useState<string>(
+    // Access the environment variable
+    import.meta.env.VITE_HEADER_TEXT || ''
+  );
+
   return (
     <>
       <Helmet>
@@ -648,6 +654,11 @@ export default function HNLiveTerminal() {
                   <span className={`inline-block w-2 h-2 rounded-full ${isRunning ? 'bg-red-500' : 'bg-gray-500'}`}></span>
                 </span>
                 LIVE
+                {headerText && (
+                  <span className="ml-4 text-sm opacity-75">
+                    {headerText}
+                  </span>
+                )}
                 {queueSize >= 100 && (
                   <span className={`absolute -top-1 -right-6 min-w-[1.2rem] h-[1.2rem] 
                     ${options.theme === 'green' ? 'bg-green-500 text-black' : 'bg-[#ff6600] text-white'} 
@@ -767,6 +778,11 @@ export default function HNLiveTerminal() {
                   <span className={`inline-block w-2 h-2 rounded-full ${isRunning ? 'bg-red-500' : 'bg-gray-500'}`}></span>
                 </span>
                 LIVE
+                {headerText && (
+                  <span className="ml-4 text-sm opacity-75">
+                    {headerText}
+                  </span>
+                )}
                 {queueSize >= 100 && (
                   <span className={`absolute -top-1 -right-6 min-w-[1.2rem] h-[1.2rem] 
                     ${options.theme === 'green' ? 'bg-green-500 text-black' : 'bg-[#ff6600] text-white'} 


### PR DESCRIPTION
This pull request includes changes to the `HNLiveTerminal` component in the `src/pages/hnlive.tsx` file. The main changes introduce a new state variable to display a header text based on an environment variable and update the component rendering to conditionally display this header text.

### Changes to `HNLiveTerminal` component:

* Added a new state variable `headerText` to store the value of the `VITE_HEADER_TEXT` environment variable.
* Updated the component rendering to conditionally display the `headerText` if it is present. [[1]](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2R657-R661) [[2]](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2R781-R785)