### PR TITLE
Enhance HNLiveTerminal with header link support and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/src/pages/hnlive.tsx
+++ b/src/pages/hnlive.tsx
@@ -602,8 +602,10 @@ export default function HNLiveTerminal() {
 
   // Add this near the top of the file with other state declarations
   const [headerText] = useState<string>(
-    // Access the environment variable
     import.meta.env.VITE_HEADER_TEXT || ''
+  );
+  const [headerLink] = useState<string>(
+    import.meta.env.VITE_HEADER_LINK || ''
   );
 
   return (
@@ -654,11 +656,6 @@ export default function HNLiveTerminal() {
                   <span className={`inline-block w-2 h-2 rounded-full ${isRunning ? 'bg-red-500' : 'bg-gray-500'}`}></span>
                 </span>
                 LIVE
-                {headerText && (
-                  <span className="ml-4 text-sm opacity-75">
-                    {headerText}
-                  </span>
-                )}
                 {queueSize >= 100 && (
                   <span className={`absolute -top-1 -right-6 min-w-[1.2rem] h-[1.2rem] 
                     ${options.theme === 'green' ? 'bg-green-500 text-black' : 'bg-[#ff6600] text-white'} 
@@ -778,11 +775,6 @@ export default function HNLiveTerminal() {
                   <span className={`inline-block w-2 h-2 rounded-full ${isRunning ? 'bg-red-500' : 'bg-gray-500'}`}></span>
                 </span>
                 LIVE
-                {headerText && (
-                  <span className="ml-4 text-sm opacity-75">
-                    {headerText}
-                  </span>
-                )}
                 {queueSize >= 100 && (
                   <span className={`absolute -top-1 -right-6 min-w-[1.2rem] h-[1.2rem] 
                     ${options.theme === 'green' ? 'bg-green-500 text-black' : 'bg-[#ff6600] text-white'} 
@@ -792,6 +784,22 @@ export default function HNLiveTerminal() {
                   </span>
                 )}
               </span>
+              {headerText && (
+                headerLink ? (
+                  <a 
+                    href={headerLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={`${headerColor} text-sm font-bold opacity-75 hover:opacity-100 transition-opacity`}
+                  >
+                    {headerText}
+                  </a>
+                ) : (
+                  <span className={`${headerColor} text-sm font-bold opacity-75`}>
+                    {headerText}
+                  </span>
+                )
+              )}
             </div>
             <div className="flex items-center gap-4">
               <button 


### PR DESCRIPTION
This pull request includes changes to the `HNLiveTerminal` component in the `src/pages/hnlive.tsx` file. The changes primarily focus on enhancing the header text functionality by introducing a new state for the header link and modifying the rendering logic for the header text.

Enhancements to header text functionality:

* Added a new state `headerLink` to store the header link value from the environment variable.
* Removed the previous rendering logic for `headerText` and replaced it with a new conditional rendering that checks for `headerLink`. If `headerLink` is present, the header text will be rendered as a clickable link; otherwise, it will be rendered as plain text. [[1]](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2L657-L661) [[2]](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2L781-L785) [[3]](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2R787-R802)