### PR TITLE
Enhance search functionality in HNLiveTerminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ You can share these URLs directly and they will load the appropriate content.
 
 - `⌘/Ctrl + S` - Start/Stop the feed
 - `⌘/Ctrl + L` - Clear the screen
-- `⌘/Ctrl + F` - Search/Filter content
+- `⌘/Ctrl + F` - Filter live feed (grep)
+- `⌘/Ctrl + K` - Search all HN content
 - `ESC` - Close story view
 
 ## Development

--- a/src/pages/hnlive.tsx
+++ b/src/pages/hnlive.tsx
@@ -537,6 +537,10 @@ export default function HNLiveTerminal() {
             e.preventDefault();
             setShowGrep(true);
             break;
+          case 'k':
+            e.preventDefault();
+            setShowSearch(true);
+            break;
         }
       }
     };
@@ -789,8 +793,9 @@ export default function HNLiveTerminal() {
                 <button
                   onClick={() => setShowSearch(true)}
                   className={themeColors}
+                  title="Ctrl/Cmd + K"
                 >
-                  [SEARCH]
+                  [SEARCH]{showShortcuts && ' (⌘K)'}
                 </button>
                 {showGrep ? (
                   <div className="flex items-center gap-2">
@@ -931,8 +936,9 @@ export default function HNLiveTerminal() {
               <button
                 onClick={() => setShowSearch(true)}
                 className={themeColors}
+                title="Ctrl/Cmd + K"
               >
-                [SEARCH]
+                [SEARCH]{showShortcuts && ' (⌘K)'}
               </button>
               {showGrep ? (
                 <div className="flex items-center gap-2">


### PR DESCRIPTION
- Updated keyboard shortcuts in README:
  - Changed '⌘/Ctrl + F' to 'Filter live feed (grep)' and added '⌘/Ctrl + K' for searching all HN content.
- Implemented '⌘/Ctrl + K' shortcut in HNLiveTerminal to trigger the search functionality.
- Updated button titles to reflect the new shortcut for better user guidance.