### PR TITLE
Add Show HN feature and update routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The site supports direct links to stories and comments:
 
 - Home feed: `/`
 - Front page: `/front`
+- Show HN: `/show`
 - Story view: `/item/123`
 - Comment view: `/item/123/comment/456`
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { HelmetProvider } from 'react-helmet-async';
 import HNLiveTerminal from "./pages/hnlive";
 import { FrontPage } from "./components/FrontPage";
+import { ShowPage } from "./components/ShowPage";
 
 function App() {
   return (
@@ -12,6 +13,7 @@ function App() {
             <Route path="front" element={null} />
             <Route path="item/:itemId" element={null} />
             <Route path="item/:itemId/comment/:commentId" element={null} />
+            <Route path="show" element={null} />
           </Route>
         </Routes>
       </Router>

--- a/src/components/ShowPage.tsx
+++ b/src/components/ShowPage.tsx
@@ -1,0 +1,245 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+interface ShowPageProps {
+  theme: 'green' | 'og' | 'dog';
+}
+
+interface HNStory {
+  id: number;
+  title: string;
+  url?: string;
+  by: string;
+  time: number;
+  score: number;
+  descendants: number;
+}
+
+const formatTimeAgo = (timestamp: number): string => {
+  const seconds = Math.floor((Date.now() - timestamp * 1000) / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (days > 0) {
+    return `${days} day${days === 1 ? '' : 's'} ago`;
+  } else if (hours > 0) {
+    return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  } else if (minutes > 0) {
+    return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+  } else {
+    return 'just now';
+  }
+};
+
+interface ShowPageState {
+  stories: HNStory[];
+  loading: boolean;
+  loadingMore: boolean;
+  page: number;
+  hasMore: boolean;
+}
+
+const STORIES_PER_PAGE = 30;
+
+export function ShowPage({ theme }: ShowPageProps) {
+  const navigate = useNavigate();
+  const [state, setState] = useState<ShowPageState>({
+    stories: [],
+    loading: true,
+    loadingMore: false,
+    page: 0,
+    hasMore: true
+  });
+
+  const fetchStories = async (pageNumber: number) => {
+    try {
+      if (pageNumber === 0) {
+        const response = await fetch('https://hacker-news.firebaseio.com/v0/showstories.json');
+        const allStoryIds = await response.json();
+        
+        const start = pageNumber * STORIES_PER_PAGE;
+        const end = start + STORIES_PER_PAGE;
+        const pageStoryIds = allStoryIds.slice(start, end);
+        
+        const storyPromises = pageStoryIds.map(async (id: number) => {
+          const storyResponse = await fetch(`https://hacker-news.firebaseio.com/v0/item/${id}.json`);
+          return storyResponse.json();
+        });
+        
+        const newStories = await Promise.all(storyPromises);
+        
+        setState(prev => ({
+          ...prev,
+          stories: newStories,
+          loading: false,
+          hasMore: end < allStoryIds.length
+        }));
+      } else {
+        setState(prev => ({ ...prev, loadingMore: true }));
+        
+        const response = await fetch('https://hacker-news.firebaseio.com/v0/showstories.json');
+        const allStoryIds = await response.json();
+        
+        const start = pageNumber * STORIES_PER_PAGE;
+        const end = start + STORIES_PER_PAGE;
+        const pageStoryIds = allStoryIds.slice(start, end);
+        
+        const storyPromises = pageStoryIds.map(async (id: number) => {
+          const storyResponse = await fetch(`https://hacker-news.firebaseio.com/v0/item/${id}.json`);
+          return storyResponse.json();
+        });
+        
+        const newStories = await Promise.all(storyPromises);
+        
+        setState(prev => ({
+          ...prev,
+          stories: [...prev.stories, ...newStories],
+          loadingMore: false,
+          hasMore: end < allStoryIds.length
+        }));
+      }
+    } catch (error) {
+      console.error('Error fetching stories:', error);
+      setState(prev => ({ 
+        ...prev, 
+        loading: false, 
+        loadingMore: false 
+      }));
+    }
+  };
+
+  useEffect(() => {
+    fetchStories(0);
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        navigate('/');
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [navigate]);
+
+  const loadMore = () => {
+    const nextPage = state.page + 1;
+    setState(prev => ({ ...prev, page: nextPage }));
+    fetchStories(nextPage);
+  };
+
+  const handleClose = () => {
+    navigate('/');
+  };
+
+  const themeColors = theme === 'green'
+    ? 'text-green-400 bg-black'
+    : theme === 'og'
+    ? 'text-[#828282] bg-[#f6f6ef]'
+    : 'text-[#828282] bg-[#1a1a1a]';
+
+  return (
+    <div className={`fixed inset-0 z-50 ${themeColors} overflow-hidden`}>
+      <div className="h-full overflow-y-auto p-4">
+        <div className="flex items-center justify-between mb-8">
+          <div className="flex items-center gap-2">
+            <span className={`${theme === 'green' ? 'text-green-500' : 'text-[#ff6600]'} font-bold tracking-wider`}>
+              HN.LIVE
+            </span>
+            <span className={`${theme === 'green' ? 'text-green-500' : 'text-[#ff6600]'} font-bold`}>
+              /
+            </span>
+            <span className={`${theme === 'green' ? 'text-green-500' : 'text-[#ff6600]'} font-bold`}>
+              SHOW HN
+            </span>
+          </div>
+          <button 
+            onClick={handleClose}
+            className="opacity-75 hover:opacity-100"
+          >
+            [ESC]
+          </button>
+        </div>
+
+        {state.loading ? (
+          <div className="flex items-center justify-center h-full">
+            Loading Show HN stories...
+          </div>
+        ) : (
+          <div className="max-w-3xl mx-auto space-y-4">
+            {state.stories.map((story, index) => (
+              <div 
+                key={story.id}
+                className="group"
+              >
+                <div className="flex items-baseline gap-2">
+                  <span className="opacity-50">{index + 1}.</span>
+                  <div className="space-y-1">
+                    <div>
+                      <a
+                        href={story.url || `https://news.ycombinator.com/item?id=${story.id}`}
+                        onClick={(e) => {
+                          if (!story.url) {
+                            e.preventDefault();
+                            navigate(`/item/${story.id}`);
+                          }
+                        }}
+                        className="group-hover:opacity-75"
+                        target={story.url ? "_blank" : undefined}
+                        rel={story.url ? "noopener noreferrer" : undefined}
+                      >
+                        {story.title}
+                      </a>
+                      {story.url && (
+                        <span className="ml-2 opacity-50 text-sm">
+                          ({new URL(story.url).hostname})
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-sm opacity-75">
+                      {story.score} points by{' '}
+                      <a 
+                        href={`https://news.ycombinator.com/user?id=${story.by}`}
+                        className="hn-username hover:underline"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {story.by}
+                      </a>{' '}
+                      <span title={new Date(story.time * 1000).toLocaleString()}>
+                        {formatTimeAgo(story.time)}
+                      </span> • {' '}
+                      <button
+                        onClick={() => navigate(`/item/${story.id}`)}
+                        className="hover:underline"
+                      >
+                        {story.descendants || 0} comments
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div className={`border-b border-current opacity-5 mt-4`} />
+              </div>
+            ))}
+
+            {state.hasMore && (
+              <div className="text-center py-8">
+                <button
+                  onClick={loadMore}
+                  disabled={state.loadingMore}
+                  className={`${
+                    theme === 'green' ? 'text-green-400' : 'text-[#ff6600]'
+                  } opacity-75 hover:opacity-100 transition-opacity disabled:opacity-50`}
+                >
+                  {state.loadingMore ? 'Loading more stories...' : 'Load more stories'}
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+} 

--- a/src/pages/hnlive.tsx
+++ b/src/pages/hnlive.tsx
@@ -5,6 +5,7 @@ import { Helmet } from 'react-helmet-async';
 import { useNavigate, useParams, useLocation, Outlet } from 'react-router-dom';
 import SearchModal from '../components/SearchModal';
 import { FrontPage } from '../components/FrontPage';
+import { ShowPage } from '../components/ShowPage';
 
 interface HNItem {
   id: number;
@@ -780,6 +781,12 @@ export default function HNLiveTerminal() {
                   [FP]
                 </button>
                 <button 
+                  onClick={() => navigate('/show')}
+                  className={themeColors}
+                >
+                  [SH]
+                </button>
+                <button 
                   onClick={() => setShowAbout(true)}
                   className={themeColors}
                 >
@@ -935,10 +942,10 @@ export default function HNLiveTerminal() {
                 [FRONT]
               </button>
               <button 
-                onClick={() => navigate('/front')}
-                className={`sm:hidden ${themeColors}`}
+                onClick={() => navigate('/show')}
+                className={`hidden sm:inline ${themeColors}`}
               >
-                [FP]
+                [SHOW]
               </button>
               <button 
                 onClick={() => setShowAbout(true)}
@@ -1150,6 +1157,11 @@ export default function HNLiveTerminal() {
           onClose={() => setShowSearch(false)}
           theme={options.theme}
         />
+
+        {/* Add the ShowPage component to the render */}
+        {location.pathname === '/show' && (
+          <ShowPage theme={options.theme} />
+        )}
       </div>
 
       <Outlet />


### PR DESCRIPTION
This pull request introduces a new feature to display "Show HN" stories on the site. The most important changes include adding a new `ShowPage` component, updating the routing to include the new page, and modifying the `HNLiveTerminal` to incorporate the new component.

### New Feature: Show HN Stories

* [`src/components/ShowPage.tsx`](diffhunk://#diff-e2a717468c5b25948b5dc5a6319d091ca851b43bddfa34af975cf575058891bbR1-R245): Added a new `ShowPage` component that fetches and displays "Show HN" stories from the Hacker News API, with functionality to load more stories, handle navigation, and apply different themes.

### Routing Updates

* [`src/App.tsx`](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R5): Updated routing to include the new `ShowPage` component, adding a route for `/show`. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R5) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R16)
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R30): Updated the documentation to include the new route `/show` for "Show HN" stories.

### Integration with HNLiveTerminal

* [`src/pages/hnlive.tsx`](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2R8): Integrated the `ShowPage` component into `HNLiveTerminal`, adding buttons and conditional rendering to navigate to and display the "Show HN" stories. [[1]](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2R8) [[2]](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2R783-R788) [[3]](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2L938-R948) [[4]](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2R1160-R1164)