### PR TITLE
Implement username colorization feature across components

### DIFF
--- a/src/components/FrontPage.tsx
+++ b/src/components/FrontPage.tsx
@@ -5,6 +5,7 @@ import { useTopUsers } from '../hooks/useTopUsers';
 interface FrontPageProps {
   theme: 'green' | 'og' | 'dog';
   fontSize: 'xs' | 'sm' | 'base';
+  colorizeUsernames: boolean;
   onShowSearch: () => void;
   onShowGrep: () => void;
   onShowSettings: () => void;
@@ -56,6 +57,7 @@ const truncateUrl = (url: string, maxLength: number): string => {
 export function FrontPage({ 
   theme, 
   fontSize,
+  colorizeUsernames,
   onShowSearch,
   onShowGrep,
   onShowSettings,
@@ -388,8 +390,10 @@ export function FrontPage({
                     <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
                       <a 
                         href={`https://news.ycombinator.com/user?id=${story.by}`}
-                        className={`hn-username hover:underline ${
-                          isTopUser(story.by) ? getTopUserClass(theme) : ''
+                        className={`hover:underline ${
+                          colorizeUsernames 
+                            ? `hn-username ${isTopUser(story.by) ? getTopUserClass(theme) : ''}`
+                            : 'opacity-75'
                         }`}
                         target="_blank"
                         rel="noopener noreferrer"

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -16,6 +16,8 @@ interface SettingsModalProps {
     directLinks: boolean;
     fontSize: 'xs' | 'sm' | 'base';
   }) => void;
+  colorizeUsernames: boolean;
+  onColorizeUsernamesChange: (value: boolean) => void;
 }
 
 const SettingsModal: React.FC<SettingsModalProps> = ({ 
@@ -23,7 +25,9 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
   onClose, 
   theme,
   options,
-  onUpdateOptions
+  onUpdateOptions,
+  colorizeUsernames,
+  onColorizeUsernamesChange
 }) => {
   // Add ESC key handler
   useEffect(() => {
@@ -135,6 +139,16 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
                 [{options.directLinks ? 'x' : ' '}] Direct HN links
               </button>
             </div>
+          </div>
+
+          <div className="space-y-2">
+            <div className="text-sm opacity-75">VIEW OPTIONS</div>
+            <button
+              onClick={() => onColorizeUsernamesChange(!colorizeUsernames)}
+              className={`hover:opacity-75 transition-opacity block`}
+            >
+              [{colorizeUsernames ? 'x' : ' '}] Colorize usernames
+            </button>
           </div>
         </div>
       </div>

--- a/src/pages/hnlive.tsx
+++ b/src/pages/hnlive.tsx
@@ -789,6 +789,17 @@ export default function HNLiveTerminal() {
     );
   };
 
+  // Add state for username colorization
+  const [colorizeUsernames, setColorizeUsernames] = useState(() => {
+    const saved = localStorage.getItem('hn-live-colorize-usernames');
+    return saved ? JSON.parse(saved) : false; // Default to false - usernames not colorized
+  });
+
+  // Add effect to save setting
+  useEffect(() => {
+    localStorage.setItem('hn-live-colorize-usernames', JSON.stringify(colorizeUsernames));
+  }, [colorizeUsernames]);
+
   return (
     <>
       <Helmet>
@@ -1250,6 +1261,7 @@ export default function HNLiveTerminal() {
           <FrontPage 
             theme={options.theme} 
             fontSize={options.fontSize}
+            colorizeUsernames={colorizeUsernames}
             onShowSearch={() => setShowSearch(true)}
             onShowGrep={() => setShowGrep(true)}
             onShowSettings={() => setShowSettings(true)}
@@ -1391,6 +1403,8 @@ export default function HNLiveTerminal() {
               console.warn('Could not save settings to localStorage');
             }
           }}
+          colorizeUsernames={colorizeUsernames}
+          onColorizeUsernamesChange={setColorizeUsernames}
         />
       </div>
 


### PR DESCRIPTION
- Added `colorizeUsernames` prop to FrontPage and SettingsModal components.
- Introduced state management for username colorization in HNLiveTerminal, with persistence in localStorage.
- Updated SettingsModal to allow users to toggle username colorization.
- Enhanced FrontPage to conditionally apply styles based on the colorization setting.

This pull request introduces a new feature to colorize usernames in the `FrontPage` and `SettingsModal` components. The changes involve adding a new `colorizeUsernames` property and handling its state across various components.

Key changes:

* **FrontPage Component Enhancements:**
  * Added a `colorizeUsernames` boolean property to the `FrontPageProps` interface and its implementation. [[1]](diffhunk://#diff-4f0fa33238bc0c17d7501ac6ba21557256d79485c4986476fbb78b58cab9657cR8) [[2]](diffhunk://#diff-4f0fa33238bc0c17d7501ac6ba21557256d79485c4986476fbb78b58cab9657cR60)
  * Modified the username display logic to apply colorization based on the `colorizeUsernames` property.

* **SettingsModal Component Enhancements:**
  * Added `colorizeUsernames` and `onColorizeUsernamesChange` properties to the `SettingsModalProps` interface and its implementation. [[1]](diffhunk://#diff-7103ebc49ca82ad2ee11176702e0ac92f867116876696977bb8c11f5e0ecab52R19-R30) [[2]](diffhunk://#diff-7103ebc49ca82ad2ee11176702e0ac92f867116876696977bb8c11f5e0ecab52R143-R152)

* **HNLiveTerminal Component Enhancements:**
  * Introduced state management for `colorizeUsernames` using `useState` and `useEffect` hooks to persist the setting in `localStorage`.
  * Passed the `colorizeUsernames` state and its setter function to the `FrontPage` and `SettingsModal` components. [[1]](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2R1264) [[2]](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2R1406-R1407)