### PR TITLE
Refactor HNLiveTerminal navigation buttons for clarity and organization

### DIFF
--- a/src/pages/hnlive.tsx
+++ b/src/pages/hnlive.tsx
@@ -1026,13 +1026,7 @@ export default function HNLiveTerminal() {
                 onClick={() => navigate('/front')}
                 className={`hidden sm:inline ${themeColors}`}
               >
-                [FRONT]
-              </button>
-              <button 
-                onClick={() => navigate('/best')}
-                className={`hidden sm:inline ${themeColors}`}
-              >
-                [BEST]
+                [FRONT PAGE]
               </button>
               <button 
                 onClick={() => navigate('/show')}
@@ -1051,6 +1045,12 @@ export default function HNLiveTerminal() {
                 className={`hidden sm:inline ${themeColors}`}
               >
                 [JOBS]
+              </button>
+              <button 
+                onClick={() => navigate('/best')}
+                className={`hidden sm:inline ${themeColors}`}
+              >
+                [BEST]
               </button>
               <button 
                 onClick={() => setShowSearch(true)}


### PR DESCRIPTION
- Updated button labels for better user understanding, changing "[FRONT]" to "[FRONT PAGE]".
- Reorganized button structure to include the "[BEST]" button, enhancing navigation options.
- Improved overall layout for a more intuitive user experience.
This pull request includes changes to the `HNLiveTerminal` component in `src/pages/hnlive.tsx` to update button labels and adjust their order. The most important changes include updating the label for the front page button and repositioning the "BEST" button.

Updates to button labels and order:

* Changed the label for the front page button from `[FRONT]` to `[FRONT PAGE]`.
* Repositioned the "BEST" button to appear after the "JOBS" button.