### PR TITLE
Enhance user experience with username colorization feature

### DIFF
--- a/src/components/AskPage.tsx
+++ b/src/components/AskPage.tsx
@@ -1,9 +1,11 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useTopUsers } from '../hooks/useTopUsers';
 
 interface AskPageProps {
   theme: 'green' | 'og' | 'dog';
   fontSize: 'xs' | 'sm' | 'base';
+  colorizeUsernames: boolean;
   onShowSearch: () => void;
   onShowGrep: () => void;
   onShowSettings: () => void;
@@ -52,6 +54,7 @@ const STORIES_PER_PAGE = 30;
 export function AskPage({ 
   theme, 
   fontSize, 
+  colorizeUsernames,
   onShowSearch, 
   onShowGrep, 
   onShowSettings,
@@ -68,6 +71,7 @@ export function AskPage({
   });
   const [showGrep, setShowGrep] = useState(false);
   const [grepFilter, setGrepFilter] = useState('');
+  const { isTopUser, getTopUserClass } = useTopUsers();
 
   const fetchStories = async (pageNumber: number) => {
     try {
@@ -332,7 +336,11 @@ export function AskPage({
                       {story.score} points by{' '}
                       <a 
                         href={`https://news.ycombinator.com/user?id=${story.by}`}
-                        className="hn-username hover:underline"
+                        className={`hover:underline ${
+                          colorizeUsernames 
+                            ? `hn-username ${isTopUser(story.by) ? getTopUserClass(theme) : ''}`
+                            : 'opacity-75'
+                        }`}
                         target="_blank"
                         rel="noopener noreferrer"
                       >

--- a/src/components/BestPage.tsx
+++ b/src/components/BestPage.tsx
@@ -1,9 +1,11 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useTopUsers } from '../hooks/useTopUsers';
 
 interface BestPageProps {
   theme: 'green' | 'og' | 'dog';
   fontSize: 'xs' | 'sm' | 'base';
+  colorizeUsernames: boolean;
   onShowSearch: () => void;
   onShowGrep: () => void;
   onShowSettings: () => void;
@@ -51,6 +53,7 @@ const STORIES_PER_PAGE = 30;
 export function BestPage({ 
   theme, 
   fontSize, 
+  colorizeUsernames, 
   onShowSearch, 
   onShowGrep, 
   onShowSettings,
@@ -67,6 +70,7 @@ export function BestPage({
   });
   const [showGrep, setShowGrep] = useState(false);
   const [grepFilter, setGrepFilter] = useState('');
+  const { isTopUser, getTopUserClass } = useTopUsers();
 
   const fetchStories = async (pageNumber: number) => {
     try {
@@ -339,7 +343,11 @@ export function BestPage({
                       {story.score} points by{' '}
                       <a 
                         href={`https://news.ycombinator.com/user?id=${story.by}`}
-                        className="hn-username hover:underline"
+                        className={`hover:underline ${
+                          colorizeUsernames 
+                            ? `hn-username ${isTopUser(story.by) ? getTopUserClass(theme) : ''}`
+                            : 'opacity-75'
+                        }`}
                         target="_blank"
                         rel="noopener noreferrer"
                       >

--- a/src/components/ShowPage.tsx
+++ b/src/components/ShowPage.tsx
@@ -1,9 +1,11 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useTopUsers } from '../hooks/useTopUsers';
 
 interface ShowPageProps {
   theme: 'green' | 'og' | 'dog';
   fontSize: 'xs' | 'sm' | 'base';
+  colorizeUsernames: boolean;
   onShowSearch: () => void;
   onShowGrep: () => void;
   onShowSettings: () => void;
@@ -48,7 +50,16 @@ interface ShowPageState {
 
 const STORIES_PER_PAGE = 30;
 
-export function ShowPage({ theme, fontSize, onShowSearch, onShowGrep, onShowSettings, isSettingsOpen, isSearchOpen }: ShowPageProps) {
+export function ShowPage({ 
+  theme, 
+  fontSize,
+  colorizeUsernames,
+  onShowSearch,
+  onShowGrep,
+  onShowSettings,
+  isSettingsOpen,
+  isSearchOpen
+}: ShowPageProps) {
   const navigate = useNavigate();
   const [state, setState] = useState<ShowPageState>({
     stories: [],
@@ -59,6 +70,7 @@ export function ShowPage({ theme, fontSize, onShowSearch, onShowGrep, onShowSett
   });
   const [showGrep, setShowGrep] = useState(false);
   const [grepFilter, setGrepFilter] = useState('');
+  const { isTopUser, getTopUserClass } = useTopUsers();
 
   const fetchStories = async (pageNumber: number) => {
     try {
@@ -343,7 +355,11 @@ export function ShowPage({ theme, fontSize, onShowSearch, onShowGrep, onShowSett
                       {story.score} points by{' '}
                       <a 
                         href={`https://news.ycombinator.com/user?id=${story.by}`}
-                        className="hn-username hover:underline"
+                        className={`hover:underline ${
+                          colorizeUsernames 
+                            ? `hn-username ${isTopUser(story.by) ? getTopUserClass(theme) : ''}`
+                            : 'opacity-75'
+                        }`}
                         target="_blank"
                         rel="noopener noreferrer"
                       >

--- a/src/pages/hnlive.tsx
+++ b/src/pages/hnlive.tsx
@@ -1301,6 +1301,7 @@ export default function HNLiveTerminal() {
             <ShowPage 
               theme={options.theme} 
               fontSize={options.fontSize}
+              colorizeUsernames={colorizeUsernames}
               onShowSearch={() => setShowSearch(true)}
               onShowGrep={() => setShowGrep(true)}
               onShowSettings={() => setShowSettings(true)}
@@ -1321,6 +1322,7 @@ export default function HNLiveTerminal() {
             <AskPage 
               theme={options.theme} 
               fontSize={options.fontSize}
+              colorizeUsernames={colorizeUsernames}
               onShowSearch={() => setShowSearch(true)}
               onShowGrep={() => setShowGrep(true)}
               onShowSettings={() => setShowSettings(true)}
@@ -1361,6 +1363,7 @@ export default function HNLiveTerminal() {
             <BestPage 
               theme={options.theme} 
               fontSize={options.fontSize}
+              colorizeUsernames={colorizeUsernames}
               onShowSearch={() => setShowSearch(true)}
               onShowGrep={() => setShowGrep(true)}
               onShowSettings={() => setShowSettings(true)}


### PR DESCRIPTION
- Added `colorizeUsernames` prop to AskPage, BestPage, and ShowPage components to conditionally style usernames based on user status.
- Integrated `useTopUsers` hook to determine top users and apply corresponding styles.
- Updated HNLiveTerminal to pass `colorizeUsernames` prop to child components, ensuring consistent behavior across the application.
This pull request introduces the `colorizeUsernames` feature to the `AskPage`, `BestPage`, and `ShowPage` components. It also integrates the `useTopUsers` hook to conditionally apply styles to top users' usernames.

Key changes include:

### New Feature: Colorize Usernames

* Added `colorizeUsernames` prop to `AskPage`, `BestPage`, and `ShowPage` components. [[1]](diffhunk://#diff-32be2f945c0091c0fe37b4aa90e6d0ceae19dce1c8110ef70a0bfd8c709b7962R3-R8) [[2]](diffhunk://#diff-62cf2f6922fa2e5e1cf06e8faf4d9705c7e7947d88daad2cc770a62285272b5aR3-R8) [[3]](diffhunk://#diff-e2a717468c5b25948b5dc5a6319d091ca851b43bddfa34af975cf575058891bbR3-R8)
* Updated the rendering logic to conditionally apply styles to usernames based on the `colorizeUsernames` prop and user status. [[1]](diffhunk://#diff-32be2f945c0091c0fe37b4aa90e6d0ceae19dce1c8110ef70a0bfd8c709b7962L335-R343) [[2]](diffhunk://#diff-62cf2f6922fa2e5e1cf06e8faf4d9705c7e7947d88daad2cc770a62285272b5aL342-R350) [[3]](diffhunk://#diff-e2a717468c5b25948b5dc5a6319d091ca851b43bddfa34af975cf575058891bbL346-R362)

### Integration of `useTopUsers` Hook

* Imported and utilized the `useTopUsers` hook in `AskPage`, `BestPage`, and `ShowPage` components to determine if a user is a top user and to get the appropriate CSS class. [[1]](diffhunk://#diff-32be2f945c0091c0fe37b4aa90e6d0ceae19dce1c8110ef70a0bfd8c709b7962R74) [[2]](diffhunk://#diff-62cf2f6922fa2e5e1cf06e8faf4d9705c7e7947d88daad2cc770a62285272b5aR73) [[3]](diffhunk://#diff-e2a717468c5b25948b5dc5a6319d091ca851b43bddfa34af975cf575058891bbR73)

### Propagation of `colorizeUsernames` Prop

* Passed the `colorizeUsernames` prop from `HNLiveTerminal` to the `AskPage`, `BestPage`, and `ShowPage` components. [[1]](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2R1304) [[2]](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2R1325) [[3]](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2R1366)