### PR TITLE
Refactor layout and username colorization defaults in HNLive

### DIFF
--- a/src/pages/hnlive.tsx
+++ b/src/pages/hnlive.tsx
@@ -110,12 +110,12 @@ const getStoredFontSize = () => {
 const getStoredLayout = () => {
   try {
     const storedLayout = localStorage.getItem('hn-live-classic-layout');
-    // Only return true if explicitly set to 'true'
-    return storedLayout === 'true';
+    // Return false only if explicitly set to 'false'
+    return storedLayout === null ? true : storedLayout === 'true';
   } catch (e) {
     console.warn('Could not access localStorage');
   }
-  return false; // Default to HN Live layout
+  return true; // Default to classic HN layout
 };
 
 // Update the style to handle both dark and green themes
@@ -805,7 +805,7 @@ export default function HNLiveTerminal() {
   // Add state for username colorization
   const [colorizeUsernames, setColorizeUsernames] = useState(() => {
     const saved = localStorage.getItem('hn-live-colorize-usernames');
-    return saved ? JSON.parse(saved) : false; // Default to false - usernames not colorized
+    return saved ? JSON.parse(saved) : true; // Default to true - usernames colorized
   });
 
   // Add effect to save setting


### PR DESCRIPTION
- Updated the logic for retrieving the stored layout preference to default to the classic layout if no explicit setting is found.
- Changed the default behavior for username colorization to be enabled by default, enhancing user experience by ensuring usernames are colorized unless specified otherwise.
- These changes improve the usability of the HNLive component by providing a more intuitive starting point for users.
This pull request includes changes to the `src/pages/hnlive.tsx` file to modify the default behavior for layout and username colorization settings. The most important changes include updating the default layout to the classic HN layout and enabling username colorization by default.

Changes to default settings:

* [`src/pages/hnlive.tsx`](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2L113-R118): Modified the `getStoredLayout` function to default to the classic HN layout if no layout is explicitly set.
* [`src/pages/hnlive.tsx`](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2L808-R808): Updated the `HNLiveTerminal` component to enable username colorization by default.