### PR TITLE
Refactor keyboard navigation in AskPage, BestPage, JobsPage, and Show…

### DIFF
--- a/src/components/AskPage.tsx
+++ b/src/components/AskPage.tsx
@@ -140,8 +140,19 @@ export function AskPage({
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && !showGrep && !isSettingsOpen && !isSearchOpen) {
-        navigate('/');
+      if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
+        e.preventDefault();
+        setShowGrep(true);
+      }
+      if (e.key === 'Escape') {
+        if (!isSettingsOpen && !isSearchOpen) {
+          if (showGrep) {
+            setGrepFilter('');
+            setShowGrep(false);
+            return;
+          }
+          navigate('/');
+        }
       }
     };
 

--- a/src/components/BestPage.tsx
+++ b/src/components/BestPage.tsx
@@ -137,8 +137,19 @@ export function BestPage({
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && !showGrep && !isSettingsOpen && !isSearchOpen) {
-        navigate('/');
+      if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
+        e.preventDefault();
+        setShowGrep(true);
+      }
+      if (e.key === 'Escape') {
+        if (!isSettingsOpen && !isSearchOpen) {
+          if (showGrep) {
+            setGrepFilter('');
+            setShowGrep(false);
+            return;
+          }
+          navigate('/');
+        }
       }
     };
 

--- a/src/components/JobsPage.tsx
+++ b/src/components/JobsPage.tsx
@@ -130,8 +130,19 @@ export function JobsPage({
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && !showGrep && !isSettingsOpen && !isSearchOpen) {
-        navigate('/');
+      if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
+        e.preventDefault();
+        setShowGrep(true);
+      }
+      if (e.key === 'Escape') {
+        if (!isSettingsOpen && !isSearchOpen) {
+          if (showGrep) {
+            setGrepFilter('');
+            setShowGrep(false);
+            return;
+          }
+          navigate('/');
+        }
       }
     };
 

--- a/src/components/ShowPage.tsx
+++ b/src/components/ShowPage.tsx
@@ -140,8 +140,19 @@ export function ShowPage({
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && !showGrep && !isSettingsOpen && !isSearchOpen) {
-        navigate('/');
+      if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
+        e.preventDefault();
+        setShowGrep(true);
+      }
+      if (e.key === 'Escape') {
+        if (!isSettingsOpen && !isSearchOpen) {
+          if (showGrep) {
+            setGrepFilter('');
+            setShowGrep(false);
+            return;
+          }
+          navigate('/');
+        }
       }
     };
 


### PR DESCRIPTION
…Page

- Updated keydown event handling to support Ctrl/Cmd + F for toggling grep filter visibility, enhancing user experience for searching.
- Improved Escape key functionality to clear grep filter and navigate home, ensuring intuitive navigation across components.
- These changes streamline user interactions and improve accessibility within the application.
This pull request includes changes to the keydown event handling logic across multiple components. The main improvements involve adding support for a new keyboard shortcut to show the grep filter and refining the logic for handling the Escape key.

Key changes:

* Added support for `Ctrl+F` or `Cmd+F` to show the grep filter in `AskPage`, `BestPage`, `JobsPage`, and `ShowPage` components. [[1]](diffhunk://#diff-32be2f945c0091c0fe37b4aa90e6d0ceae19dce1c8110ef70a0bfd8c709b7962L143-R156) [[2]](diffhunk://#diff-62cf2f6922fa2e5e1cf06e8faf4d9705c7e7947d88daad2cc770a62285272b5aL140-R153) [[3]](diffhunk://#diff-beb65e5b594c6d42cd34851c6512ab89d5e4779afb8065eb244c7c09d7b17f8dL133-R146) [[4]](diffhunk://#diff-e2a717468c5b25948b5dc5a6319d091ca851b43bddfa34af975cf575058891bbL143-R156)
* Enhanced the Escape key handling logic to close the grep filter and reset its state before navigating away in `AskPage`, `BestPage`, `JobsPage`, and `ShowPage` components. [[1]](diffhunk://#diff-32be2f945c0091c0fe37b4aa90e6d0ceae19dce1c8110ef70a0bfd8c709b7962L143-R156) [[2]](diffhunk://#diff-62cf2f6922fa2e5e1cf06e8faf4d9705c7e7947d88daad2cc770a62285272b5aL140-R153) [[3]](diffhunk://#diff-beb65e5b594c6d42cd34851c6512ab89d5e4779afb8065eb244c7c09d7b17f8dL133-R146) [[4]](diffhunk://#diff-e2a717468c5b25948b5dc5a6319d091ca851b43bddfa34af975cf575058891bbL143-R156)