### PR TITLE
Enhance SettingsModal and HNLiveTerminal components with showCommentP…

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -10,6 +10,7 @@ interface SettingsModalProps {
     directLinks: boolean;
     fontSize: 'xs' | 'sm' | 'base';
     classicLayout: boolean;
+    showCommentParents: boolean;
   };
   onUpdateOptions: (newOptions: {
     theme: 'green' | 'og' | 'dog';
@@ -17,6 +18,7 @@ interface SettingsModalProps {
     directLinks: boolean;
     fontSize: 'xs' | 'sm' | 'base';
     classicLayout: boolean;
+    showCommentParents: boolean;
   }) => void;
   colorizeUsernames: boolean;
   onColorizeUsernamesChange: (value: boolean) => void;
@@ -45,6 +47,9 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
       return () => window.removeEventListener('keydown', handleKeyDown);
     }
   }, [isOpen, onClose]);
+
+  // Add state for showing the reload message
+  const [showReloadMessage, setShowReloadMessage] = useState(false);
 
   if (!isOpen) return null;
 
@@ -124,7 +129,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
             </div>
           </div>
 
-          {/* Terminal Behavior Options */}
+          {/* Terminal Behavior */}
           <div className="space-y-2">
             <div className="text-sm opacity-75">TERMINAL BEHAVIOR</div>
             <div className="space-y-2">
@@ -140,9 +145,27 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
               >
                 [{options.directLinks ? 'x' : ' '}] Direct HN links
               </button>
+              <button
+                onClick={() => {
+                  onUpdateOptions({ ...options, showCommentParents: !options.showCommentParents });
+                  setShowReloadMessage(true);
+                  setTimeout(() => setShowReloadMessage(false), 1000);
+                }}
+                className={`hover:opacity-75 transition-opacity block w-full text-left`}
+              >
+                <div className="flex items-center gap-2">
+                  <span>[{options.showCommentParents ? 'x' : ' '}] Show story context</span>
+                  {showReloadMessage && (
+                    <span className="text-sm opacity-75">
+                      [reload required]
+                    </span>
+                  )}
+                </div>
+              </button>
             </div>
           </div>
 
+          {/* View Options */}
           <div className="space-y-2">
             <div className="text-sm opacity-75">VIEW OPTIONS</div>
             <div className="space-y-2">


### PR DESCRIPTION
…arents feature

- Added showCommentParents option to SettingsModal for user preference.
- Implemented logic in HNLiveTerminal to fetch and display parent story context for comments when enabled.
- Introduced localStorage handling for persisting user preference on comment parent visibility.
- Updated UI elements to reflect changes and provide feedback on reload requirements.
This pull request introduces a new feature to show the parent story context for comments in the HN Live Terminal and includes several related changes to the `SettingsModal` and `hnlive.tsx` files.

### New Feature: Show Parent Story Context

* **Added `showCommentParents` option**:
  - [`src/components/SettingsModal.tsx`](diffhunk://#diff-7103ebc49ca82ad2ee11176702e0ac92f867116876696977bb8c11f5e0ecab52R13-R21): Updated `SettingsModalProps` and `onUpdateOptions` to include the `showCommentParents` option.
  - [`src/pages/hnlive.tsx`](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2R46): Updated `TerminalOptions` interface to include `showCommentParents`.

* **State Management**:
  - [`src/components/SettingsModal.tsx`](diffhunk://#diff-7103ebc49ca82ad2ee11176702e0ac92f867116876696977bb8c11f5e0ecab52R51-R53): Added `useState` to manage the `showReloadMessage` state.
  - [`src/pages/hnlive.tsx`](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2R122-R131): Added `getStoredCommentParents` function to retrieve the `showCommentParents` state from `localStorage`.
  - [`src/pages/hnlive.tsx`](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2L150-R162): Updated initial state in `HNLiveTerminal` to include `showCommentParents`.

* **UI Updates**:
  - [`src/components/SettingsModal.tsx`](diffhunk://#diff-7103ebc49ca82ad2ee11176702e0ac92f867116876696977bb8c11f5e0ecab52R148-R168): Added a button to toggle the `showCommentParents` option and display a reload message when the option is changed.

* **Fetching Parent Story**:
  - [`src/pages/hnlive.tsx`](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2L220-R263): Implemented logic to fetch and display the parent story context for comments.

* **Persistence**:
  - [`src/pages/hnlive.tsx`](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2R880-R888): Added an effect to save the `showCommentParents` preference to `localStorage`.