### PR TITLE
Reduce initial comment load in StoryView for improved performance

### DIFF
--- a/src/components/StoryView.tsx
+++ b/src/components/StoryView.tsx
@@ -35,7 +35,7 @@ interface HNComment {
   hasDeepReplies?: boolean;
 }
 
-const MAX_COMMENTS = 10;  // Maximum number of top-level comments to load
+const MAX_COMMENTS = 2;  // Reduced from 5 to 2 for faster initial load
 const MAX_DEPTH = 5;     // Maximum nesting depth for replies
 
 // Add this at the top of the file
@@ -399,18 +399,18 @@ export function StoryView({ itemId, scrollToId, onClose, theme, fontSize }: Stor
             requiredIds = new Set(targetCommentChain);
           }
 
-          // Always load first 10 comments
-          const firstTenComments = storyData.kids.slice(0, MAX_COMMENTS);
+          // Load first few comments instead of 10
+          const firstFewComments = storyData.kids.slice(0, MAX_COMMENTS);
           
-          // If our target comment's thread isn't in first 10, add it
+          // If our target comment's thread isn't in first 5, add it
           const topLevelParentId = targetCommentChain[0];
-          if (scrollToId && !firstTenComments.includes(topLevelParentId)) {
-            firstTenComments.push(topLevelParentId);
+          if (scrollToId && !firstFewComments.includes(topLevelParentId)) {
+            firstFewComments.push(topLevelParentId);
           }
 
           // Load all these comments
           initialComments = await fetchComments(
-            firstTenComments,
+            firstFewComments,
             0,
             requiredIds,
             true // Force load the entire chain


### PR DESCRIPTION
- Decreased the maximum number of top-level comments loaded from 10 to 2 to enhance initial loading speed.
- Updated related logic to reflect the new comment limit, ensuring accurate handling of target comment threads.
- Improved overall user experience by optimizing comment fetching and rendering.
This pull request includes changes to the `StoryView` component in `src/components/StoryView.tsx` to improve the initial load time by reducing the number of top-level comments fetched initially. The changes primarily focus on optimizing the performance of the comment loading process.

Performance optimization:

* [`src/components/StoryView.tsx`](diffhunk://#diff-ea9143b77145d06c65c0ef8b26143306fd98a703bbdea6f7496bf27f13f5ece3L38-R38): Reduced the `MAX_COMMENTS` constant from 10 to 2 to decrease the initial load time.
* [`src/components/StoryView.tsx`](diffhunk://#diff-ea9143b77145d06c65c0ef8b26143306fd98a703bbdea6f7496bf27f13f5ece3L402-R413): Updated the logic to load the first few comments instead of the first ten comments, and adjusted related conditions to reflect this change.