### PR TITLE
Feature/story view long content

### DIFF
--- a/src/components/StoryView.tsx
+++ b/src/components/StoryView.tsx
@@ -767,7 +767,7 @@ export function StoryView({ itemId, scrollToId, onClose, theme, fontSize, font, 
           {!commentState?.collapsedComments?.has(comment.id) && (
             <>
               <div 
-                className="prose max-w-none mb-4 break-words whitespace-pre-wrap overflow-hidden"
+                className="prose max-w-none mb-4 break-words whitespace-pre-wrap overflow-x-auto px-2 max-w-full"
                 dangerouslySetInnerHTML={{ 
                   __html: addTargetBlankToLinks(comment.text) 
                 }} 
@@ -963,7 +963,7 @@ export function StoryView({ itemId, scrollToId, onClose, theme, fontSize, font, 
               Loading...
             </div>
           ) : story ? (
-            <div className="max-w-4xl mx-auto px-0 sm:px-4">
+            <div className="max-w-4xl mx-auto px-2 sm:px-4">
               <div className="flex items-start justify-between gap-2">
                 <h1 className="text-xl font-bold mb-2 flex items-start gap-2">
                   {story.url ? (
@@ -1038,7 +1038,7 @@ export function StoryView({ itemId, scrollToId, onClose, theme, fontSize, font, 
               </div>
               {story.text && (
                 <div 
-                  className="prose max-w-none mb-8 break-words whitespace-pre-wrap overflow-hidden"
+                  className="prose max-w-none mb-8 break-words whitespace-pre-wrap overflow-x-auto px-2 max-w-full"
                   dangerouslySetInnerHTML={{ __html: addTargetBlankToLinks(story.text) }}
                 />
               )}

--- a/src/components/StoryView.tsx
+++ b/src/components/StoryView.tsx
@@ -13,6 +13,7 @@ interface StoryViewProps {
   fontSize: string;
   font: FontOption;
   onShowSettings: () => void;
+  isSettingsOpen: boolean;
 }
 
 interface HNStory {
@@ -349,7 +350,7 @@ const countReplies = (comment: HNComment): number => {
   return count;
 };
 
-export function StoryView({ itemId, scrollToId, onClose, theme, fontSize, font, onShowSettings }: StoryViewProps) {
+export function StoryView({ itemId, scrollToId, onClose, theme, fontSize, font, onShowSettings, isSettingsOpen }: StoryViewProps) {
   const navigate = useNavigate();
   const { isTopUser, getTopUserClass } = useTopUsers();
   
@@ -636,6 +637,10 @@ export function StoryView({ itemId, scrollToId, onClose, theme, fontSize, font, 
             searchTerm: '',
             matchedComments: []
           }));
+        } else if (viewingUser) {
+          setViewingUser(null);
+        } else if (isSettingsOpen) {
+          onShowSettings(); // Close settings modal
         } else {
           navigate('/');
         }
@@ -644,7 +649,7 @@ export function StoryView({ itemId, scrollToId, onClose, theme, fontSize, font, 
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [navigate, grepState.isActive]);
+  }, [navigate, grepState.isActive, viewingUser, isSettingsOpen, onShowSettings]);
 
   useEffect(() => {
     // Track story view

--- a/src/pages/hnlive.tsx
+++ b/src/pages/hnlive.tsx
@@ -1503,6 +1503,7 @@ export default function HNLiveTerminal() {
             fontSize={options.fontSize}
             font={options.font}
             onShowSettings={() => setShowSettings(true)}
+            isSettingsOpen={showSettings}
           />
         )}
 


### PR DESCRIPTION
This pull request includes changes to the `StoryView` component in `src/components/StoryView.tsx` and the `HNLiveTerminal` component in `src/pages/hnlive.tsx`. The primary focus is on adding a new prop to manage the settings modal state and improving the layout for better user experience.

### State management improvements:

* [`src/components/StoryView.tsx`](diffhunk://#diff-ea9143b77145d06c65c0ef8b26143306fd98a703bbdea6f7496bf27f13f5ece3R16): Added a new prop `isSettingsOpen` to the `StoryViewProps` interface and updated the `StoryView` component to handle the settings modal state. [[1]](diffhunk://#diff-ea9143b77145d06c65c0ef8b26143306fd98a703bbdea6f7496bf27f13f5ece3R16) [[2]](diffhunk://#diff-ea9143b77145d06c65c0ef8b26143306fd98a703bbdea6f7496bf27f13f5ece3L352-R353) [[3]](diffhunk://#diff-ea9143b77145d06c65c0ef8b26143306fd98a703bbdea6f7496bf27f13f5ece3R640-R643) [[4]](diffhunk://#diff-ea9143b77145d06c65c0ef8b26143306fd98a703bbdea6f7496bf27f13f5ece3L647-R652)
* [`src/pages/hnlive.tsx`](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2R1506): Passed the `isSettingsOpen` prop to the `StoryView` component to manage the settings modal state.

### Layout improvements:

* [`src/components/StoryView.tsx`](diffhunk://#diff-ea9143b77145d06c65c0ef8b26143306fd98a703bbdea6f7496bf27f13f5ece3L770-R775): Modified the class names for various elements to improve the layout, including adding horizontal overflow handling and padding. [[1]](diffhunk://#diff-ea9143b77145d06c65c0ef8b26143306fd98a703bbdea6f7496bf27f13f5ece3L770-R775) [[2]](diffhunk://#diff-ea9143b77145d06c65c0ef8b26143306fd98a703bbdea6f7496bf27f13f5ece3L966-R971) [[3]](diffhunk://#diff-ea9143b77145d06c65c0ef8b26143306fd98a703bbdea6f7496bf27f13f5ece3L1041-R1046)