### PR TITLE
Enhance SettingsModal account section with logout functionality

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -84,7 +84,8 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
   const [collapsedSections, setCollapsedSections] = useState({
     terminal: true,
     feedView: true,
-    storyView: true
+    storyView: true,
+    account: true
   });
 
   // Add state for HN username input
@@ -93,11 +94,9 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
   const [validationError, setValidationError] = useState<string | null>(null);
 
   // Toggle handler for sections
-  const toggleSection = (section: 'terminal' | 'feedView' | 'storyView') => {
+  const toggleSection = (section: 'terminal' | 'feedView' | 'storyView' | 'account') => {
     setCollapsedSections(prev => ({
-      terminal: true,
-      feedView: true,
-      storyView: true,
+      ...prev,
       [section]: !prev[section]
     }));
   };
@@ -467,6 +466,12 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
                       <div className="opacity-75">Connected as: {hnUsername}</div>
                       <button
                         onClick={() => {
+                          // Clear only the keys we're actually using
+                          localStorage.removeItem('hn-username');
+                          localStorage.removeItem('hn-new-replies');
+                          localStorage.removeItem('hn-unread-count');
+                          localStorage.removeItem('hn-comment-tracker');
+                          
                           onUpdateHnUsername(null);
                           setUsernameInput('');
                           setValidationError(null);


### PR DESCRIPTION
- Add 'account' section to collapsible settings sections
- Implement localStorage cleanup when disconnecting HN username
- Improve section toggle logic to preserve other section states
This pull request includes updates to the `SettingsModal` component in `src/components/SettingsModal.tsx` to add a new section for account settings and improve the handling of local storage items.

Enhancements to `SettingsModal`:

* Added a new `account` section to the `collapsedSections` state to manage the visibility of the account settings section.
* Updated the `toggleSection` function to include the new `account` section, allowing it to be toggled along with other sections.
* Improved the `onClick` handler for the button to clear specific local storage items related to the HN username and its associated data.