### PR TITLE
Add visited link styling for different themes

### DIFF
--- a/src/components/BestPage.tsx
+++ b/src/components/BestPage.tsx
@@ -408,7 +408,12 @@ export function BestPage({
                                 navigate(`/item/${story.id}`);
                               }
                             }}
-                            className="group-hover:opacity-75"
+                            className={`
+                              group-hover:opacity-75
+                              ${story.url && theme === 'green' && 'visited:text-green-600/30'}
+                              ${story.url && theme === 'og' && 'visited:text-[#999999]'}
+                              ${story.url && theme === 'dog' && 'visited:text-[#666666]'}
+                            `}
                             target={story.url ? "_blank" : undefined}
                             rel={story.url ? "noopener noreferrer" : undefined}
                           >
@@ -488,7 +493,12 @@ export function BestPage({
                                 navigate(`/item/${story.id}`);
                               }
                             }}
-                            className="group-hover:opacity-75 font-medium"
+                            className={`
+                              group-hover:opacity-75 font-medium
+                              ${story.url && theme === 'green' && 'visited:text-green-600/30'}
+                              ${story.url && theme === 'og' && 'visited:text-[#999999]'}
+                              ${story.url && theme === 'dog' && 'visited:text-[#666666]'}
+                            `}
                             target={story.url ? "_blank" : undefined}
                             rel={story.url ? "noopener noreferrer" : undefined}
                           >

--- a/src/components/FrontPage.tsx
+++ b/src/components/FrontPage.tsx
@@ -417,7 +417,12 @@ export function FrontPage({
                                 navigate(`/item/${story.id}`);
                               }
                             }}
-                            className="group-hover:opacity-75"
+                            className={`
+                              group-hover:opacity-75
+                              ${story.url && theme === 'green' && 'visited:text-green-600/30'}
+                              ${story.url && theme === 'og' && 'visited:text-[#999999]'}
+                              ${story.url && theme === 'dog' && 'visited:text-[#666666]'}
+                            `}
                             target={story.url ? "_blank" : undefined}
                             rel={story.url ? "noopener noreferrer" : undefined}
                           >
@@ -498,7 +503,12 @@ export function FrontPage({
                                 navigate(`/item/${story.id}`);
                               }
                             }}
-                            className="group-hover:opacity-75 font-medium"
+                            className={`
+                              group-hover:opacity-75
+                              ${story.url && theme === 'green' && 'visited:text-green-600/30'}
+                              ${story.url && theme === 'og' && 'visited:text-[#999999]'}
+                              ${story.url && theme === 'dog' && 'visited:text-[#666666]'}
+                            `}
                             target={story.url ? "_blank" : undefined}
                             rel={story.url ? "noopener noreferrer" : undefined}
                           >

--- a/src/components/JobsPage.tsx
+++ b/src/components/JobsPage.tsx
@@ -354,7 +354,12 @@ export function JobsPage({
                               navigate(`/item/${job.id}`);
                             }
                           }}
-                          className="group-hover:opacity-75"
+                          className={`
+                            group-hover:opacity-75
+                            ${job.url && theme === 'green' && 'visited:text-green-600/30'}
+                            ${job.url && theme === 'og' && 'visited:text-[#999999]'}
+                            ${job.url && theme === 'dog' && 'visited:text-[#666666]'}
+                          `}
                           target={job.url ? "_blank" : undefined}
                           rel={job.url ? "noopener noreferrer" : undefined}
                         >

--- a/src/components/ShowPage.tsx
+++ b/src/components/ShowPage.tsx
@@ -433,7 +433,12 @@ export function ShowPage({
                                 navigate(`/item/${story.id}`);
                               }
                             }}
-                            className="group-hover:opacity-75"
+                            className={`
+                              group-hover:opacity-75
+                              ${story.url && theme === 'green' && 'visited:text-green-600/30'}
+                              ${story.url && theme === 'og' && 'visited:text-[#999999]'}
+                              ${story.url && theme === 'dog' && 'visited:text-[#666666]'}
+                            `}
                             target={story.url ? "_blank" : undefined}
                             rel={story.url ? "noopener noreferrer" : undefined}
                           >
@@ -508,7 +513,12 @@ export function ShowPage({
                                 navigate(`/item/${story.id}`);
                               }
                             }}
-                            className="group-hover:opacity-75 font-medium"
+                            className={`
+                              group-hover:opacity-75 font-medium
+                              ${story.url && theme === 'green' && 'visited:text-green-600/30'}
+                              ${story.url && theme === 'og' && 'visited:text-[#999999]'}
+                              ${story.url && theme === 'dog' && 'visited:text-[#666666]'}
+                            `}
                             target={story.url ? "_blank" : undefined}
                             rel={story.url ? "noopener noreferrer" : undefined}
                           >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -31,5 +31,10 @@ export default {
       },
     },
   },
+  safelist: [
+    {
+      pattern: /visited:/,
+    },
+  ],
   plugins: [],
 } 


### PR DESCRIPTION
- Implement theme-specific visited link color styles
- Add Tailwind safelist for dynamic visited link classes
- Update story link components across multiple pages to support visited link styling
This pull request includes updates to the `className` attributes in multiple components to dynamically apply different styles based on the `theme` prop. The changes ensure that visited links have different colors depending on the theme.

Changes to `className` attributes:

* [`src/components/BestPage.tsx`](diffhunk://#diff-62cf2f6922fa2e5e1cf06e8faf4d9705c7e7947d88daad2cc770a62285272b5aL411-R416): Updated `className` to dynamically apply styles based on the `theme` prop for visited links. [[1]](diffhunk://#diff-62cf2f6922fa2e5e1cf06e8faf4d9705c7e7947d88daad2cc770a62285272b5aL411-R416) [[2]](diffhunk://#diff-62cf2f6922fa2e5e1cf06e8faf4d9705c7e7947d88daad2cc770a62285272b5aL491-R501)
* [`src/components/FrontPage.tsx`](diffhunk://#diff-4f0fa33238bc0c17d7501ac6ba21557256d79485c4986476fbb78b58cab9657cL420-R425): Updated `className` to dynamically apply styles based on the `theme` prop for visited links. [[1]](diffhunk://#diff-4f0fa33238bc0c17d7501ac6ba21557256d79485c4986476fbb78b58cab9657cL420-R425) [[2]](diffhunk://#diff-4f0fa33238bc0c17d7501ac6ba21557256d79485c4986476fbb78b58cab9657cL501-R511)
* [`src/components/JobsPage.tsx`](diffhunk://#diff-beb65e5b594c6d42cd34851c6512ab89d5e4779afb8065eb244c7c09d7b17f8dL357-R362): Updated `className` to dynamically apply styles based on the `theme` prop for visited links.
* [`src/components/ShowPage.tsx`](diffhunk://#diff-e2a717468c5b25948b5dc5a6319d091ca851b43bddfa34af975cf575058891bbL436-R441): Updated `className` to dynamically apply styles based on the `theme` prop for visited links. [[1]](diffhunk://#diff-e2a717468c5b25948b5dc5a6319d091ca851b43bddfa34af975cf575058891bbL436-R441) [[2]](diffhunk://#diff-e2a717468c5b25948b5dc5a6319d091ca851b43bddfa34af975cf575058891bbL511-R521)