### PR TITLE
Adjust PWA font size setting to 'sm' for better readability

### DIFF
--- a/src/pages/hnlive.tsx
+++ b/src/pages/hnlive.tsx
@@ -84,9 +84,8 @@ const getStoredSettings = () => {
     const defaultSize = (() => {
       const isPWA = window.matchMedia('(display-mode: standalone)').matches;
       const isMobile = window.innerWidth < 640; // 640px is Tailwind's 'sm' breakpoint
-      // In PWA mode, we use base size for better readability
       if (isPWA) {
-        return 'base' as const;
+        return 'sm' as const;
       }
       return isMobile ? 'sm' as const : 'base' as const;
     })();


### PR DESCRIPTION
This pull request includes a change to the `src/pages/hnlive.tsx` file, specifically in the `getStoredSettings` function. The change modifies the default size setting for better readability in PWA mode.

* [`src/pages/hnlive.tsx`](diffhunk://#diff-8c5b4bbeba004419168db02c8a006aeda1d9b9f2eaf4416aabeb9d1b8184ccb2L87-R88): Changed the default size in PWA mode from 'base' to 'sm' for improved readability.